### PR TITLE
CBP-21176: s3-upload-object action fails if artifact is not registered

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
          fi
 
           # API call to publish artifact info
-          response=$(curl --fail-with-body -X 'POST' "$CLOUDBEES_API_URL/v3/artifactinfos" \
+          response=$(curl --retry-delay 5 --retry 3 --retry-connrefused --fail-with-body -X 'POST' "$CLOUDBEES_API_URL/v3/artifactinfos" \
             -H "Authorization: Bearer $CLOUDBEES_API_TOKEN" \
             -H 'Content-Type: application/json' \
             --data-binary "$json_payload") || command_failed=1

--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
          fi
 
           # API call to publish artifact info
-          response=$(curl --retry-delay 5 --retry 3 --retry-connrefused --fail-with-body -X 'POST' "$CLOUDBEES_API_URL/v3/artifactinfos1" \
+          response=$(curl --retry-delay 5 --retry 3 --retry-connrefused --fail-with-body -X 'POST' "$CLOUDBEES_API_URL/v3/artifactinfos" \
             -H "Authorization: Bearer $CLOUDBEES_API_TOKEN" \
             -H 'Content-Type: application/json' \
             --data-binary "$json_payload") || command_failed=1

--- a/action.yml
+++ b/action.yml
@@ -126,9 +126,9 @@ runs:
 
           # Check curl exit code
           if [ ${command_failed:-0} -eq 1 ]; then
-            echo "WARN: failed to save artifact information: '$response'"
+            echo "ERROR: failed to save artifact information: '$response'"
           else
-            echo "Artifact details pushed to platform successfully"
+            echo "Artifact details pushed to CloudBees platform successfully"
             
             # Extract the artifactId
             id=$(echo "$response" | grep -o '"id": *"[^"]*"' | sed 's/.*"id": *"\([^"]*\)".*/\1/')
@@ -137,7 +137,10 @@ runs:
             printf %s "$id" > $CLOUDBEES_OUTPUTS/artifact-id
           fi
         else
-          echo "Artifact information not sent to Platform"
+          echo "Artifact information not sent to CloudBees platform"
+          # Output an empty artifact-id output parameter when 
+          # no artifact version info is registered with CloudBees platform
+          echo "" > $CLOUDBEES_OUTPUTS/artifact-id
         fi    
     - name: publish-evidence
       uses: cloudbees-io/publish-evidence-item@v1

--- a/action.yml
+++ b/action.yml
@@ -127,6 +127,7 @@ runs:
           # Check curl exit code
           if [ ${command_failed:-0} -eq 1 ]; then
             echo "ERROR: failed to save artifact information: '$response'"
+            exit 1
           else
             echo "Artifact details pushed to CloudBees platform successfully"
             

--- a/action.yml
+++ b/action.yml
@@ -119,7 +119,7 @@ runs:
          fi
 
           # API call to publish artifact info
-          response=$(curl --retry-delay 5 --retry 3 --retry-connrefused --fail-with-body -X 'POST' "$CLOUDBEES_API_URL/v3/artifactinfos" \
+          response=$(curl --retry-delay 5 --retry 3 --retry-connrefused --fail-with-body -X 'POST' "$CLOUDBEES_API_URL/v3/artifactinfos1" \
             -H "Authorization: Bearer $CLOUDBEES_API_TOKEN" \
             -H 'Content-Type: application/json' \
             --data-binary "$json_payload") || command_failed=1


### PR DESCRIPTION
o Return an error and fail the action in case the API call to register artifact info version fails.
o Output an empty artifact-id output parameter when send-artifact-info== false and no artifact version info is registered.
o Add retry options in curl command to retry API request in case of transient errors when communicating with CBP

Test workflow run: https://cloudbees.io/cloudbees/8ddcfaa1-ab3e-4c7b-4d5c-64d7d9cae6fb/components/0e434030-660f-412d-896f-9dbb16d8e1f3/runs/d83bdfb9-37c9-4c8b-9dbb-4dbe7edeea79/488f67ea-e04f-49c1-a2ab-e423008ec391/1/logs?componentId=0e434030-660f-412d-896f-9dbb16d8e1f3&workflowId=d83bdfb9-37c9-4c8b-9dbb-4dbe7edeea79&organizationId=8ddcfaa1-ab3e-4c7b-4d5c-64d7d9cae6fb
